### PR TITLE
Closes #3 Add warning when discarding return value of filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor
 composer.lock
+/Tests/Integration/.phpunit.result.cache
+/Tests/Unit/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It is also a a proof of concept for a WordPress change that has been proposed in
 ## Limitation
 If the end value type returned by the filter doesn't match the initial value type, the end value is discarded and the initial (default) one is returned. It's a limitation caused by the impossibility to access the internals of the hook system.
 
+If the value is discarded, an error message will be added to the error.log when `WP_DEBUG` is enabled: `Return value of "hook_name" filter must be of the type "expected", "unexpected" returned.`
+
 The patch proposed to core handles the situation better, discarding callbacks that return an unexpected type instead of discarding the final value.
 
 ##  Installation

--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,8 @@ function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 	$next_value = apply_filters( $hook_name, $value, ...$args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 
 	if ( ! wpm_is_type( $type, $next_value ) ) {
+		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', $hook_name, $type, gettype( $next_value ) ), '1.0.1' );
+
 		return $value;
 	}
 

--- a/functions.php
+++ b/functions.php
@@ -25,7 +25,7 @@ function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 	$next_value = apply_filters( $hook_name, $value, ...$args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 
 	if ( ! wpm_is_type( $type, $next_value ) ) {
-		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', $hook_name, $type, gettype( $next_value ) ), '1.0.1' );
+		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
 
 		return $value;
 	}

--- a/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
@@ -5,12 +5,14 @@ return [
 		'type' => 'boolean',
 		'value' => true,
 		'filter_return' => 'string',
+		'warning' => true,
 		'expected' => true,
 	],
 	'testShouldReturnExpected' => [
 		'type' => 'boolean',
 		'value' => false,
 		'filter_return' => true,
+		'warning' => false,
 		'expected' => true,
 	],
 ];

--- a/tests/Fixtures/Functions/wpmApplyFiltersTypesafe.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTypesafe.php
@@ -4,11 +4,13 @@ return [
 	'testShouldReturnOriginalValueWhenFilterReturnsIncorrectType' => [
 		'value' => true,
 		'filter_return' => 'string',
+		'warning' => true,
 		'expected' => true,
 	],
 	'testShouldReturnExpected' => [
 		'value' => false,
 		'filter_return' => true,
+		'warning' => false,
 		'expected' => true,
 	],
 ];

--- a/tests/Integration/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Integration/Functions/wpmApplyFiltersTyped.php
@@ -18,10 +18,14 @@ class TestWpmApplyFiltersTyped extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $type, $value, $filter_return, $expected ) {
+	public function testShouldReturnExpected( $type, $value, $filter_return, $warning, $expected ) {
 		$this->filter_value = $filter_return;
 
 		add_filter( 'hook_name', [ $this, 'return_filter_value' ] );
+
+		if ( $warning ) {
+			$this->setExpectedIncorrectUsage( 'wpm_apply_filters_typed' );
+		}
 
 		$this->assertSame(
 			$expected,

--- a/tests/Unit/Functions/wpmApplyFiltersTypesafe.php
+++ b/tests/Unit/Functions/wpmApplyFiltersTypesafe.php
@@ -12,6 +12,8 @@ class TestWpmApplyFiltersTypesafe extends TestCase {
 	 * @dataProvider configTestData
 	 */
 	public function testShouldReturnExpected( $value, $filter_return, $warning, $expected ) {
+		$this->stubEscapeFunctions();
+
 		Filters\expectApplied( 'hook_name' )
 			->once()
 			->with( $value )

--- a/tests/Unit/Functions/wpmApplyFiltersTypesafe.php
+++ b/tests/Unit/Functions/wpmApplyFiltersTypesafe.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace WPMedia\ApplyFiltersTyped\Tests\Unit\Functions;
 
-use Brain\Monkey\Filters;
+use Brain\Monkey\{Filters, Functions};
 use WPMedia\ApplyFiltersTyped\Tests\Unit\TestCase;
 
 class TestWpmApplyFiltersTypesafe extends TestCase {
 	/**
 	 * @dataProvider configTestData
 	 */
-	public function testShouldReturnExpected( $value, $filter_return, $expected ) {
+	public function testShouldReturnExpected( $value, $filter_return, $warning, $expected ) {
 		Filters\expectApplied( 'hook_name' )
 			->once()
 			->with( $value )
 			->andReturn( $filter_return );
+		
+		if ( $warning ) {
+			Functions\expect( '_doing_it_wrong' )
+				->once();
+		} else {
+			Functions\expect( '_doing_it_wrong' )
+				->never();
+		}
 
 		$this->assertSame(
 			$expected,


### PR DESCRIPTION
# Description

Fixes #3

## Documentation

### User documentation

A warning will be displayed in the error log if the value returned by the filter is not matching with the expected type.

### Technical documentation

Uses `_doing_it_wrong()` to output the error.

## Type of change
- [x] Enhancement (non-breaking change which improves an existing functionality).

# Checklists

## Feature validation

- [x] I validated all the Acceptance Criteria. If possible, provide sreenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Documentation

- [x] I prepared the user documentation for the feature/enhancement and shared it in the PR or the GitHub issue.
- [x] The user documentation covers new/changed entry points (endpoints, WP hooks, configuration files, ...).
- [x] I prepared the technical documentation if needed, and shared it in the PR or the GitHub issue.

## Code style
- [x] I wrote self-explanatory code about what it does.
- [x] I named variables and functions explicitely.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unecessary complexity.