### PR TITLE
Closes #6 Add support for union types

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -56,6 +56,8 @@ function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
  * @return bool Whether the variable is of the type.
  */
 function wpm_is_type( $type, $value ) {
+	$type = strtolower( $type );
+
 	switch ( $type ) {
 		case 'boolean':
 			return is_bool( $value );
@@ -72,8 +74,12 @@ function wpm_is_type( $type, $value ) {
 		case 'resource':
 		case 'resource (closed)':
 			return is_resource( $value );
-		case 'NULL':
+		case 'null':
 			return is_null( $value );
+		case 'false':
+			return false === $value;
+		case 'true':
+			return true === $value;
 		case 'unknown_type':
 			return false;
 		default:

--- a/functions.php
+++ b/functions.php
@@ -24,30 +24,23 @@ function wpm_apply_filters_typesafe( $hook_name, $value, ...$args ) {
 function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 	$next_value = apply_filters( $hook_name, $value, ...$args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 
+	$types = [ $type ];
+
 	// Union types are separated by a pipe character.
 	if ( preg_match( '/\|/i', $type ) ) {
 		$types = explode( '|', $type );
+	}
 
-		foreach ( $types as $type ) {
-			if ( wpm_is_type( $type, $next_value ) ) {
-				return $next_value;
-			}
+	foreach ( $types as $type ) {
+		if ( wpm_is_type( $type, $next_value ) ) {
+			return $next_value;
 		}
-
-		// None of the types matched.
-		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
-
-		return $value;
 	}
 
-	// Single type.
-	if ( ! wpm_is_type( $type, $next_value ) ) {
-		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
+	// None of the types matched.
+	_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
 
-		return $value;
-	}
-
-	return $next_value;
+	return $value;
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -24,6 +24,23 @@ function wpm_apply_filters_typesafe( $hook_name, $value, ...$args ) {
 function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 	$next_value = apply_filters( $hook_name, $value, ...$args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound
 
+	// Union types are separated by a pipe character.
+	if ( preg_match( '/\|/i', $type ) ) {
+		$types = explode( '|', $type );
+
+		foreach ( $types as $type ) {
+			if ( wpm_is_type( $type, $next_value ) ) {
+				return $next_value;
+			}
+		}
+
+		// None of the types matched.
+		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
+
+		return $value;
+	}
+
+	// Single type.
 	if ( ! wpm_is_type( $type, $next_value ) ) {
 		_doing_it_wrong( __FUNCTION__, sprintf( 'Return value of "%1$s" filter must be of the type "%2$s", "%3$s" returned.', esc_attr( $hook_name ), esc_attr( $type ), esc_attr( gettype( $next_value ) ) ), '1.0.1' );
 

--- a/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
@@ -15,4 +15,18 @@ return [
 		'warning' => false,
 		'expected' => true,
 	],
+	'testShouldReturnStringWhenUnionType' => [
+		'type' => 'boolean|string',
+		'value' => 'string',
+		'filter_return' => 'string',
+		'warning' => false,
+		'expected' => 'string',
+	],
+	'testShouldReturnNullWhenUnionType' => [
+		'type' => 'NULL|string',
+		'value' => 'string',
+		'filter_return' => null,
+		'warning' => false,
+		'expected' => null,
+	],
 ];

--- a/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
@@ -29,4 +29,11 @@ return [
 		'warning' => false,
 		'expected' => null,
 	],
+	'testShouldReturnOriginalWhenUnionTypeNotMatched' => [
+		'type' => 'NULL|string',
+		'value' => 'string',
+		'filter_return' => 0,
+		'warning' => true,
+		'expected' => 'string',
+	],
 ];


### PR DESCRIPTION
# Description

Fixes #6

Add support for union types in `wpm_apply_filters_typed()`, i.e. `int|string` type declaration.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Using the following:

`$value = wpm_apply_filters_typed( 'int|string', 'wpm_filter_test', 'toto' );`

Adding a callback function that return either a int or a string should generate a `$value` with the value returned by the callback.

Add a callback function that returns something else than a int or a string should generate a `$value`  with the default `toto` value and also raise a warning.

## Technical description

### Documentation

The added code checks if the `$type` contains the union character `|`, if yes, it explodes the type string and loops over each value of the array to check if the resulting value of the filter matches with at least one of the types provided. The code bails-out as soon as one match is found.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

# Additional Checks
- [x] In the case of complex code, I wrote comments to explain it.
- [x] When possible, I prepared ways to observe the implemented system (logs, data, etc.).