### PR TITLE
Closes #8 Add support for typed arrays

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -58,12 +58,30 @@ function wpm_apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 function wpm_is_type( $type, $value ) {
 	$type = strtolower( $type );
 
+	// Check if the type is nullable.
 	if ( '?' === substr( $type, 0, 1 ) ) {
 		$type = substr( $type, 1 );
 
 		if ( is_null( $value ) ) {
 			return true;
 		}
+	}
+
+	// Check if the type is an array of a certain type.
+	if ( '[]' === substr( $type, -2 ) ) {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		$type = substr( $type, 0, -2 );
+
+		foreach ( $value as $item ) {
+			if ( ! wpm_is_type( $type, $item ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	switch ( $type ) {

--- a/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
@@ -50,6 +50,19 @@ return [
 		'warning' => false,
 		'expected' => null,
 	],
+	'testShouldReturnOriginalWhenArrayOfStringsNotArray' => [
+		'type' => 'string[]',
+		'value' => [
+			'string1',
+			'string2',
+		],
+		'filter_return' => 0,
+		'warning' => true,
+		'expected' => [
+			'string1',
+			'string2',
+		],
+	],
 	'testShouldReturnOriginalWhenArrayOfStringsNotMatched' => [
 		'type' => 'string[]',
 		'value' => [

--- a/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
+++ b/tests/Fixtures/Functions/wpmApplyFiltersTyped.php
@@ -50,4 +50,38 @@ return [
 		'warning' => false,
 		'expected' => null,
 	],
+	'testShouldReturnOriginalWhenArrayOfStringsNotMatched' => [
+		'type' => 'string[]',
+		'value' => [
+			'string1',
+			'string2',
+		],
+		'filter_return' => [
+			'string1',
+			0,
+		],
+		'warning' => true,
+		'expected' => [
+			'string1',
+			'string2',
+		],
+	],
+	'testShouldReturnArrayOfStringsWhenArrayOfStrings' => [
+		'type' => 'string[]',
+		'value' => [
+			'string1',
+			'string2',
+		],
+		'filter_return' => [
+			'string1',
+			'string2',
+			'string3',
+		],
+		'warning' => false,
+		'expected' => [
+			'string1',
+			'string2',
+			'string3',
+		],
+	],
 ];


### PR DESCRIPTION
# Description

Fixes #8

Add support for typed arrays, i.e. `string[]`.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

Using the following:

`$value = wpm_apply_filters_typed( 'string[]', 'wpm_filter_test', [ 'string1', 'string2' ] );`

Adding a callback function that return either an array of strings should generate a `$value` with the value returned by the callback.

Add a callback function that returns something else than an array, and an array that doesn't only contain strings should generate a `$value` with the default value and also raise a warning.

## Technical description

### Documentation

Add a check if the type provided ends with `[]`. If yes:
- Check if the `$value` is an array, bail-out if not
- For each items of the array, check that its type matches (`string[]` should contain only `string` items)

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.